### PR TITLE
Expiry refactoring

### DIFF
--- a/webform_confirm_email.admin.inc
+++ b/webform_confirm_email.admin.inc
@@ -663,31 +663,23 @@ function theme_webform_confirm_email_email_add_form($form) {
 }
 
 function webform_confirm_email_settings($form, &$form_state, $node) {
+  $form['#node'] = $node;
+  $form['#tree'] = TRUE;
   $lifetime = array(
     'days'    => NULL,
     'hours'   => NULL,
     'minutes' => NULL,
   );
-  $delete_submissions = FALSE;
-  if (!empty($node)) {
-    $form['#node'] = $node;
 
-    $result = db_query(
-      'SELECT request_lifetime, delete_submissions ' .
-      '  FROM {webform_confirm_email} ' .
-      '    WHERE nid = :nid ' .
-      '  LIMIT 1 ' ,
-      array(':nid' => $node->nid)
-    )->fetchObject();
-    if (isset($result->request_lifetime) && isset($result->delete_submissions)) {
-      $delete_submissions  = $result->delete_submissions;
-      $lifetime['days']    = (int) ($result->request_lifetime / 86400);
-      $lifetime['hours']   = (int)(($result->request_lifetime % 86400) / 3600);
-      $lifetime['minutes'] = (int)(($result->request_lifetime % 86400) % 3600) / 60;
-      foreach (array('days', 'hours', 'minutes') as $key) {
-        if ($lifetime[$key] == 0) {
-          $lifetime[$key] = NULL;
-        }
+  $request_lifetime = $node->webform['confirm_email_request_lifetime'];
+  $delete_submissions = $node->webform['confirm_email_delete_submissions'];
+  if ($request_lifetime) {
+    $lifetime['days']    = (int) ($request_lifetime / 86400);
+    $lifetime['hours']   = (int)(($request_lifetime % 86400) / 3600);
+    $lifetime['minutes'] = (int)(($request_lifetime % 86400) % 3600) / 60;
+    foreach (array('days', 'hours', 'minutes') as $key) {
+      if ($lifetime[$key] == 0) {
+        $lifetime[$key] = NULL;
       }
     }
   }
@@ -701,7 +693,7 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
     '#weight'      => 0,
   );
 
-  $form['request_lifetime']['lifetime-container'] = array(
+  $form['request_lifetime']['lifetime'] = array(
     '#type'      => 'container',
     '#attributes' => array(
       'class' => array(
@@ -710,7 +702,7 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
     ),
   );
 
-  $form['request_lifetime']['lifetime-container']['days'] = array(
+  $form['request_lifetime']['lifetime']['days'] = array(
     '#type'          => 'textfield',
     '#title'         => t('Days'),
     '#maxlength'     => 3,
@@ -722,7 +714,7 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
       ),
     ),
   );
-  $form['request_lifetime']['lifetime-container']['hours'] = array(
+  $form['request_lifetime']['lifetime']['hours'] = array(
     '#type'          => 'textfield',
     '#title'         => t('Hours'),
     '#maxlength'     => 2,
@@ -734,7 +726,7 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
       ),
     ),
   );
-  $form['request_lifetime']['lifetime-container']['minutes'] = array(
+  $form['request_lifetime']['lifetime']['minutes'] = array(
     '#type'          => 'textfield',
     '#title'         => t('Minutes'),
     '#maxlength'     => 2,
@@ -746,7 +738,7 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
       ),
     ),
   );
-  $form['request_lifetime']['lifetime-container']['delete_submissions'] = array(
+  $form['request_lifetime']['delete_submissions'] = array(
     '#type'          => 'checkbox',
     '#title'         => t('Delete submissions'),
     '#description'   => t('If checked then not only webform_confirm_email\'s internal data but also the submissions themselfs will be deleted. If unchecked, only webform_confirm_email\'s internal data will be deleted.'),
@@ -767,48 +759,32 @@ function webform_confirm_email_settings($form, &$form_state, $node) {
 }
 
 function webform_confirm_email_settings_validate($form, &$form_state) {
+  $values = &drupal_array_get_nested_value($form_state['values'], $form['#parents']);
+  $v = $values['request_lifetime']['lifetime'];
 
   foreach(array('days', 'hours', 'minutes') as $field_name) {
-    if (   !empty($form_state['values'][$field_name])
-        && preg_match('/^\d*$/', $form_state['values'][$field_name]) != 1) {
-      form_error($form['request_lifetime'][$field_name], t('The entered value %value is not a number.', array('%value' => $form_state['values'][$field_name])));
+    if (!empty($v[$field_name]) && preg_match('/^\d*$/', $v[$field_name]) != 1) {
+      form_error($form['request_lifetime']['lifetime'][$field_name], t('The entered value %value is not a number.', array('%value' => $form_state['values'][$field_name])));
     }
   }
-  if (   !empty($form_state['values']['hours'])
-      && (int) $form_state['values']['hours'] > 23) {
-    form_error($form['request_lifetime']['hours'], t('Hours must be smaller than 24.'));
+  if (!empty($v['hours']) && (int) $v['hours'] > 23) {
+    form_error($form['request_lifetime']['lifetime']['hours'], t('Hours must be smaller than 24.'));
   }
-  if (   !empty($form_state['values']['minutes'])
-      && (int) $form_state['values']['minutes'] > 59) {
-    form_error($form['request_lifetime']['minutes'], t('Minutes must be smaller than 60.'));
+  if (!empty($v['minutes']) && (int) $v['minutes'] > 59) {
+    form_error($form['request_lifetime']['lifetime']['minutes'], t('Minutes must be smaller than 60.'));
   }
+
+  $values['request_lifetime']['lifetime'] = (int) $v['days'] * 86400
+    + (int) $v['hours'] * 3600 + (int) $v['minutes'] * 60;
+
 }
 
 function webform_confirm_email_settings_submit($form, &$form_state) {
-  if (!empty($form['#node'])) {
-    $lifetime = 0;
-    if (!empty($form_state['values']['days'])) {
-      $lifetime += (int) $form_state['values']['days'] * 86400;
-    }
-    if (!empty($form_state['values']['hours'])) {
-      $lifetime += (int) $form_state['values']['hours'] * 3600;
-    }
-    if (!empty($form_state['values']['minutes'])) {
-      $lifetime += (int) $form_state['values']['minutes'] * 60;
-    }
+  $values = &drupal_array_get_nested_value($form_state['values'], $form['#parents']);
+  $w = &$form['#node']->webform;
+  $w['confirm_email_request_lifetime'] = $values['request_lifetime']['lifetime'];
+  $w['confirm_email_delete_submissions'] = $values['request_lifetime']['delete_submissions'];
+  node_save($form['#node']);
 
-    db_query(
-      'UPDATE {webform_confirm_email} ' .
-      '  SET request_lifetime   = :lifetime , ' .
-      '      delete_submissions = :delete_submissions ' .
-      '  WHERE nid = :nid ' ,
-      array(
-        ':lifetime'           => $lifetime,
-        ':nid'                => $form['#node']->nid,
-        ':delete_submissions' => $form_state['values']['delete_submissions'],
-      )
-    );
-
-    drupal_set_message(t('The confirmation mail settings have been updated.'));
-  }
+  drupal_set_message(t('The confirmation mail settings have been updated.'));
 }

--- a/webform_confirm_email.install
+++ b/webform_confirm_email.install
@@ -123,18 +123,15 @@ function webform_confirm_email_schema() {
 
 /**
  * Implements hook_schema_alter().
- *
  */
 function webform_confirm_email_schema_alter(&$schema) {
-  if (isset($schema['webform_submissions']) == TRUE) {
-    $schema['webform_submissions']['confirmed'] = array(
-      'description' => 'True if the email address for this submission was already confirmed.',
-      'type'        => 'int',
-      'size'        => 'tiny',
-      'not null'    => TRUE,
-      'default'     => 0,
-    );
-  }
+  $schema['webform_submission']['fields']['confirmed'] = array(
+    'description' => 'True if the email address for this submission was already confirmed.',
+    'type'        => 'int',
+    'size'        => 'tiny',
+    'not null'    => TRUE,
+    'default'     => 0,
+  );
 }
 
 /**

--- a/webform_confirm_email.install
+++ b/webform_confirm_email.install
@@ -102,18 +102,6 @@ function webform_confirm_email_schema() {
         'length'      => 255,
         'not null'    => FALSE,
       ),
-      'request_lifetime' => array(
-        'description' => 'Time in seconds after which an unconfirmed confirmation request may be deleted for this webform. NULL means don\'t delete requests',
-        'type'        => 'int',
-        'not null'    => FALSE,
-      ),
-      'delete_submissions' => array(
-        'description' => 'If set to TRUE also webform submissions with unconfirmed confirmation requests will be deleted by chron for this webform. NULL means don\'t delete any submissions',
-        'type'        => 'int',
-        'size'        => 'tiny',
-        'not null'    => FALSE,
-        'default'     => 0,
-      ),
     ),
     'primary key' => array('nid', 'eid'),
   );
@@ -132,13 +120,33 @@ function webform_confirm_email_schema_alter(&$schema) {
     'not null'    => TRUE,
     'default'     => 0,
   );
+  $schema['webform']['fields']['confirm_email_request_lifetime'] = array(
+    'description' => 'Time in seconds after which an unconfirmed confirmation request may be deleted for this webform. NULL means don\'t delete requests',
+    'type'        => 'int',
+    'not null'    => FALSE,
+  );
+  $schema['webform']['fields']['confirm_email_delete_submissions'] = array(
+    'description' => 'If set to TRUE also webform submissions with unconfirmed confirmation requests will be deleted by chron for this webform. NULL means don\'t delete any submissions',
+    'type'        => 'int',
+    'size'        => 'tiny',
+    'not null'    => FALSE,
+    'default'     => 0,
+  );
 }
 
 /**
  * Implements hook_install().
  */
 function webform_confirm_email_install() {
-  _webform_confirm_email_add_column_to_webform_submissions();
+  $schema = [];
+  webform_confirm_email_schema_alter($schema);
+  foreach ($schema as $table => $def) {
+    foreach ($def['fields'] as $field => $field_def) {
+      if (!db_field_exists($table, $field)) {
+        db_add_field($table, $field, $field_def);
+      }
+    }
+  }
 }
 
 /**
@@ -164,14 +172,57 @@ function _webform_confirm_email_add_column_to_webform_submissions() {
  * Implements hook_uninstall().
  */
 function webform_confirm_email_uninstall() {
-  if (db_table_exists('webform_submissions') && db_field_exists('webform_submissions', 'confirmed')) {
-    db_drop_field('webform_submissions', 'confirmed');
+  $schema = [];
+  webform_confirm_email_schema_alter($schema);
+  foreach ($schema as $table => $def) {
+    foreach ($def['fields'] as $field => $field_def) {
+      if (db_field_exists($table, $field)) {
+        db_drop_field($table, $field);
+      }
+    }
   }
 }
 
 // *****************************************
 // **************** UPDATES ****************
 // *****************************************
+
+/**
+ * Migrate to expiration config columns in {webform}.
+ */
+function webform_confirm_email_update_7205() {
+  // Add new fields.
+  db_add_field('webform', 'confirm_email_request_lifetime', array(
+    'description' => 'Time in seconds after which an unconfirmed confirmation request may be deleted for this webform. NULL means don\'t delete requests',
+    'type'        => 'int',
+    'not null'    => FALSE,
+  ));
+  db_add_field('webform', 'confirm_email_delete_submissions', array(
+    'description' => 'If set to TRUE also webform submissions with expired confirmation requests will be deleted by cron for this webform. NULL means don\'t delete any submissions',
+    'type'        => 'int',
+    'size'        => 'tiny',
+    'not null'    => FALSE,
+    'default'     => 0,
+  ));
+
+  // Migrate data.
+  $sql = <<<SQL
+UPDATE {webform} w
+  INNER JOIN (
+    SELECT nid, MAX(request_lifetime) AS request_lifetime,
+      MAX(delete_submissions) AS delete_submissions
+    FROM {webform_confirm_email}
+    GROUP BY nid
+  ) x USING(nid)
+SET w.confirm_email_request_lifetime=x.request_lifetime,
+  w.confirm_email_delete_submissions=x.delete_submissions
+SQL;
+  db_query($sql);
+
+  // Drop old fields.
+  db_drop_field('webform_confirm_email', 'request_lifetime');
+  db_drop_field('webform_confirm_email', 'delete_submissions');
+}
 
 /**
  * Migrate old-style tokens.

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -586,12 +586,9 @@ Your petition team"';
 function webform_confirm_email_cron() {
   // get all node id's that we have to check for expired requests
   $nids_lifetime = db_query(
-    'SELECT confirm.nid, confirm.request_lifetime, confirm.delete_submissions ' .
-    '  FROM {webform_confirm_email_code} code ' .
-    '  INNER JOIN {webform_confirm_email} confirm ' .
-    '    ON code.nid = confirm.nid ' .
-    '  WHERE confirm.request_lifetime IS NOT NULL ' .
-    '  GROUP BY confirm.nid, confirm.request_lifetime, confirm.delete_submissions'
+    'SELECT nid, confirm_email_request_lifetime, confirm_email_delete_submissions ' .
+    '  FROM {webform} ' .
+    '  WHERE confirm_email_request_lifetime IS NOT NULL '
     )->fetchAllAssoc('nid');
 
   if (!empty($nids_lifetime)) {
@@ -599,7 +596,7 @@ function webform_confirm_email_cron() {
       $expired_sids = array();
       // calculate the oldets timestamp that is still not expired
       // for this nid;
-      $timestamp = REQUEST_TIME - $settings->request_lifetime;
+      $timestamp = REQUEST_TIME - $settings->confirm_email_request_lifetime;
       $expired_sids[$nid] = db_query(
         'SELECT sid ' .
         '  FROM {webform_confirm_email_code} ' .
@@ -630,7 +627,7 @@ function webform_confirm_email_cron() {
         );
       }
       module_invoke_all('webform_confirm_email_request_expired', $expired_sids);
-      if ($settings->delete_submissions) {
+      if ($settings->confirm_email_delete_submissions) {
         require_once drupal_get_path('module', 'webform') . '/includes/webform.submissions.inc';
         $node = node_load($nid);
         foreach ($expired_sids[$nid] as $sid) {


### PR DESCRIPTION
* Use the {webform} table to store settings instead of storing the configuration *multiple times* in {webform_confirm_email}.
* Refactor the form to be embeddable.