### PR TITLE
Extend confirmed hook with a first_confirmation parameter.

### DIFF
--- a/webform_confirm_email.api.php
+++ b/webform_confirm_email.api.php
@@ -1,26 +1,24 @@
 <?php
+
 /**
  * @file
+ * Document hooks invoked by this module.
  */
-
 
 /**
- * React on an email that was confirmed when the user clicked
- * the confirmation link
+ * React when a confirmation link was clicked.
  *
- * @param $node
- *   The node object of the webform for which an email was confirmed
- *
- * @param $submission
- *   The submission object of the webform submission where the user
- *   just confirmed his/her email address
+ * @param object $node
+ *   The webform node of the the submission.
+ * @param object $submission
+ *   The confirmed webform submission.
+ * @param bool $first_confirmation
+ *   TRUE the first time a confirmation link for this submission was clicked.
  */
-function hook_webform_confirm_email_email_confirmed($node, $submission) {
-  db_query(
-    'INSERT INTO {my_confirmed_submission_list} ' .
-    '  VALUES (:nid, :sid) ',
-    array(':nid' => $node->nid, ':sid' => $submission->sid)
-  );
+function hook_webform_confirm_email_email_confirmed($node, $submission, $first_confirmation) {
+  db_insert('my_confirmed_submission_list')
+    ->fields(['nid' => $node->nid, 'sid' => $submission->sid])
+    ->execute();
 }
 
 /**

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -121,6 +121,7 @@ function webform_confirm_email_confirmation($node, $submission, $eid) {
     ->condition('nid', $node->nid)
     ->condition('sid', $submission->sid)
     ->execute();
+  $first_confirmation = !$submission->confirmed;
   $submission->confirmed = 1;
 
   $messages = db_select('webform_confirm_email_queued_emails', 'e')
@@ -173,9 +174,9 @@ function webform_confirm_email_confirmation($node, $submission, $eid) {
     ->execute();
 
   // Let other modules react to the submission being confirmed.
-  module_invoke_all('webform_confirm_email_email_confirmed', $node, $submission);
+  module_invoke_all('webform_confirm_email_email_confirmed', $node, $submission, $first_confirmation);
   if (module_exists('rules') == TRUE) {
-    rules_invoke_event('webform_confirm_email_email_confirmed', $node, $submission);
+    rules_invoke_event('webform_confirm_email_email_confirmed', $node, $submission, $first_confirmation);
   }
   $redirect_url = db_query(
     'SELECT redirect_url ' .


### PR DESCRIPTION
At the moment the hook is invoked everytime a confirmation URL is opened in a browser. Some users of the hook might prefer to execute their code only once. Adding an additional parameter is an API-compatible way of enabling that.