### PR TITLE
Integrate confirmed to webform results

### DIFF
--- a/webform_confirm_email.install
+++ b/webform_confirm_email.install
@@ -90,9 +90,6 @@ function webform_confirm_email_schema_alter(&$schema) {
   $schema['webform_submissions']['fields']['confirmed'] = array(
     'description' => 'True if the email address for this submission was already confirmed.',
     'type'        => 'int',
-    'size'        => 'tiny',
-    'not null'    => TRUE,
-    'default'     => 0,
   );
   $schema['webform']['fields']['confirm_email_request_lifetime'] = array(
     'description' => 'Time in seconds after which an unconfirmed confirmation request may be deleted for this webform. NULL means don\'t delete requests',
@@ -160,6 +157,30 @@ function webform_confirm_email_uninstall() {
 // *****************************************
 // **************** UPDATES ****************
 // *****************************************
+
+/**
+ * Turn webform_submissions confirmed into a timestamp.
+ */
+function webform_confirm_email_update_7211() {
+  db_change_field('webform_submissions', 'confirmed', 'confirmed', array(
+    'description' => 'Timestamp of when the email address for this submission was first confirmed, otherwise NULL',
+    'type'        => 'int',
+  ));
+  db_update('webform_submissions')
+    ->fields(['confirmed' => NULL])
+    ->condition('confirmed', 0)
+    ->execute();
+  db_update('webform_submissions')
+    ->expression('confirmed', 'completed')
+    ->isNotNull('confirmed')
+    ->execute();
+  // Edge-case: Use a truish value even if $submission->completed was 0.
+  db_update('webform_submissions')
+    ->fields(['confirmed' => 1])
+    ->condition('completed', 0)
+    ->isNotNull('confirmed')
+    ->execute();
+}
 
 /**
  * Re-run 7208 for installations that have run it already.

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -746,7 +746,7 @@ function webform_confirm_email_results_batch_rows($node, $format = 'delimited', 
  */
 function webform_confirm_email_webform_results_download_submission_information_info() {
   return array(
-    'confirmed' => t('Confirmed Time'),
+    'webform_confirm_email_confirmed' => t('Confirmed Time'),
   );
 }
 
@@ -755,14 +755,14 @@ function webform_confirm_email_webform_results_download_submission_information_i
  */
 function webform_confirm_email_webform_results_download_submission_information_info_alter(array &$submission_information) {
   // Move Confirmed Time column after Modified Time column.
-  if (isset($submission_information['webform_modified_time']) && isset($submission_information['confirmed'])) {
-    $confirmed = $submission_information['confirmed'];
-    unset($submission_information['confirmed']);
+  if (isset($submission_information['webform_modified_time']) && isset($submission_information['webform_confirm_email_confirmed'])) {
+    $confirmed = $submission_information['webform_confirm_email_confirmed'];
+    unset($submission_information['webform_confirm_email_confirmed']);
     $new_info = [];
     foreach ($submission_information as $column => $label) {
       $new_info[$column] = $label;
       if ($column == 'webform_modified_time') {
-        $new_info['confirmed'] = $confirmed;
+        $new_info['webform_confirm_email_confirmed'] = $confirmed;
       }
     }
     $submission_information = $new_info;
@@ -775,8 +775,8 @@ function webform_confirm_email_webform_results_download_submission_information_i
  * This is only used without the patch from #3086038.
  */
 function webform_confirm_email_webform_results_download_submission_information_data($token, $submission, array $options, $serial_start, $row_count) {
-  if ($token == 'confirmed') {
-    return webform_confirm_email_webform_results_download_submission_information_data_row($submission, $options, $serial_start, $row_count)['confirmed'];
+  if ($token == 'webform_confirm_email_confirmed') {
+    return webform_confirm_email_webform_results_download_submission_information_data_row($submission, $options, $serial_start, $row_count)['webform_confirm_email_confirmed'];
   }
 }
 
@@ -793,7 +793,7 @@ function webform_confirm_email_webform_results_download_submission_information_d
   } : function ($timestamp) {
     return format_date($timestamp, 'short');
   };
-  $data['confirmed'] = $submission->confirmed ? $format_date($submission->confirmed) : '';
+  $data['webform_confirm_email_confirmed'] = $submission->confirmed ? $format_date($submission->confirmed) : '';
   return $data;
 }
 

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -117,12 +117,12 @@ function webform_confirm_email_confirmation_access($node, $submission, $eid, $co
  */
 function webform_confirm_email_confirmation($node, $submission, $eid) {
   db_update('webform_submissions')
-    ->fields(array('confirmed' => 1))
+    ->fields(array('confirmed' => $_SERVER['REQUEST_TIME']))
     ->condition('nid', $node->nid)
     ->condition('sid', $submission->sid)
     ->execute();
-  $first_confirmation = !$submission->confirmed;
-  $submission->confirmed = 1;
+  $first_confirmation = is_null($submission->confirmed);
+  $submission->confirmed = $_SERVER['REQUEST_TIME'];
 
   $messages = db_select('webform_confirm_email_queued_emails', 'e')
     ->fields('e', array('email'))
@@ -640,8 +640,12 @@ function _webform_confirm_email_range_confirmed($value = NULL) {
 function webform_confirm_email_query_webform_download_sids_alter($query) {
   $confirmed = _webform_confirm_email_range_confirmed();
   if (!empty($confirmed)) {
-    $op = $confirmed == WEBFORM_CONFIRM_EMAIL_FILTER_CONFIRMED ? '>' : '=';
-    $query->condition('ws.confirmed', 0, $op);
+    if ($confirmed == WEBFORM_CONFIRM_EMAIL_FILTER_CONFIRMED) {
+      $query->isNotNull('ws.confirmed');
+    }
+    else {
+      $query->isNull('ws.confirmed');
+    }
   }
 }
 

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -740,3 +740,40 @@ function webform_confirm_email_results_batch_rows($node, $format = 'delimited', 
   }
   webform_results_batch_rows($node, $format, $options, $context);
 }
+
+/**
+ * Implements hook_webform_results_download_submission_information_info().
+ */
+function webform_confirm_email_webform_results_download_submission_information_info() {
+  return array(
+    'confirmed' => t('Confirmed Time'),
+  );
+}
+
+/**
+ * Implements hook_webform_results_download_submission_information_data().
+ *
+ * This is only used without the patch from #3086038.
+ */
+function webform_confirm_email_webform_results_download_submission_information_data($token, $submission, array $options, $serial_start, $row_count) {
+  if ($token == 'confirmed') {
+    return webform_confirm_email_webform_results_download_submission_information_data_row($submission, $options, $serial_start, $row_count)['confirmed'];
+  }
+}
+
+/**
+ * Implements hook_webform_results_download_submission_information_data_row().
+ *
+ * This hook is invoked directly if
+ * @link https://www.drupal.org/node/3086038 #3086038 @endlink
+ * is applied.
+ */
+function webform_confirm_email_webform_results_download_submission_information_data_row($submission, array $options, $serial_start, $row_count) {
+  $format_date = !empty($options['iso8601_date']) ? function($timestamp) {
+    return format_date($timestamp, 'custom', 'Y-m-d\TH:i:s');
+  } : function($timestamp) {
+    return format_date($timestamp, 'short');
+  };
+  $data['confirmed'] = $submission->confirmed ? $format_date($submission->confirmed) : 'not confirmed.';
+  return $data;
+}

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -751,6 +751,25 @@ function webform_confirm_email_webform_results_download_submission_information_i
 }
 
 /**
+ * Implements hook_webform_results_download_submission_information_info_alter().
+ */
+function webform_confirm_email_webform_results_download_submission_information_info_alter(array &$submission_information) {
+  // Move Confirmed Time column after Modified Time column.
+  if (isset($submission_information['webform_modified_time']) && isset($submission_information['confirmed'])) {
+    $confirmed = $submission_information['confirmed'];
+    unset($submission_information['confirmed']);
+    $new_info = [];
+    foreach ($submission_information as $column => $label) {
+      $new_info[$column] = $label;
+      if ($column == 'webform_modified_time') {
+        $new_info['confirmed'] = $confirmed;
+      }
+    }
+    $submission_information = $new_info;
+  }
+}
+
+/**
  * Implements hook_webform_results_download_submission_information_data().
  *
  * This is only used without the patch from #3086038.

--- a/webform_confirm_email.module
+++ b/webform_confirm_email.module
@@ -769,11 +769,12 @@ function webform_confirm_email_webform_results_download_submission_information_d
  * is applied.
  */
 function webform_confirm_email_webform_results_download_submission_information_data_row($submission, array $options, $serial_start, $row_count) {
-  $format_date = !empty($options['iso8601_date']) ? function($timestamp) {
+  $format_date = !empty($options['iso8601_date']) ? function ($timestamp) {
     return format_date($timestamp, 'custom', 'Y-m-d\TH:i:s');
-  } : function($timestamp) {
+  } : function ($timestamp) {
     return format_date($timestamp, 'short');
   };
-  $data['confirmed'] = $submission->confirmed ? $format_date($submission->confirmed) : 'not confirmed.';
+  $data['confirmed'] = $submission->confirmed ? $format_date($submission->confirmed) : '';
   return $data;
 }
+


### PR DESCRIPTION
This adds confirmation date to the webform_results export.
For this we migrate the current confirmed boolean field to a timestamp, and then we implement webform_results_download_submission_information_* hook to add the column.